### PR TITLE
fix: dropdown menu cut off

### DIFF
--- a/desktop/src/components/inputs/TypeableSelect/autoCompleteBase.jsx
+++ b/desktop/src/components/inputs/TypeableSelect/autoCompleteBase.jsx
@@ -335,6 +335,7 @@ class Autocomplete extends React.PureComponent {
             },
           }}
           options={options}
+          menuPosition='fixed'
           components={components}
           onChange={(value) => setFieldValue(field.name, value.id)}
           value={this.getValueFromOptions(options)}


### PR DESCRIPTION
-Dropdown menus that show up in Employees -> Filter, as well as in Tasks -> Filter are not cut off anymore and show up either in full length or with scroll (if too long).

### Before


![Screenshot from 2024-04-02 20-34-44](https://github.com/joshuawootonn/time-track/assets/68671029/6391db52-8710-433f-9b53-bc68f66d0aed)


### After



![Screenshot from 2024-04-02 20-37-04](https://github.com/joshuawootonn/time-track/assets/68671029/20d25ce8-47fa-45a9-bf97-7ea54ecef8bb)

