### PR TITLE
fix: clocking out with task other

### DIFF
--- a/desktop/src/containers/Clock/clockOutContainer.jsx
+++ b/desktop/src/containers/Clock/clockOutContainer.jsx
@@ -20,6 +20,18 @@ import {
 } from '~/store/selectors'
 import { minutesRoudedTime } from '~/helpers/time'
 
+function isActivityCompleted(activity, projectTaskObjects) {
+  const { projectTaskId, description } = activity
+
+  const isOtherTask =
+    projectTaskId !== -1 &&
+    projectTaskObjects &&
+    projectTaskObjects[projectTaskId] &&
+    /Other/.test(projectTaskObjects[projectTaskId].task.name)
+
+  return isOtherTask ? description.length > 0 : true
+}
+
 export class ClockOut extends Component {
   constructor(props) {
     super(props)
@@ -91,18 +103,13 @@ export class ClockOut extends Component {
           //console.log(formikProps.values);
           const { errors, values } = formikProps
           let generalError
-          values.activities.forEach((activity) => {
-            const { projectTaskId } = activity
-            const { projectTaskObjects } = this.props
-            if (
-              projectTaskId !== -1 &&
-              projectTaskObjects &&
-              projectTaskObjects[projectTaskId] &&
-              /Other/.test(projectTaskObjects[projectTaskId].task.name)
-            ) {
-              generalError = `Add description to Other activity.`
-            }
-          })
+          const areAllOtherTasksDescribed = values.activities.every((activity) =>
+            isActivityCompleted(activity, this.props.projectTaskObjects),
+          )
+          if (!areAllOtherTasksDescribed) {
+              generalError = "Add description to Other activity"
+          }
+          
 
           // Time left is the duraction - lunch - all the activity times
           let timeLeft =


### PR DESCRIPTION
### Mechanism

By design, if the user chose "Task" of type "Other", he/she must enter values into "Description" field in order to clockout. If "Description" field is left blank, "Add description to Other activity" error message pops up and "CLOCK OUT" button is unclickable.

### Bug

The user cannot clockout with the "Task" of type "Other", the error message "Add description to Other activity" shows up even when there is text in the "Description".

![Screenshot from 2024-04-07 00-58-16](https://github.com/joshuawootonn/time-track/assets/68671029/ab74364b-447a-42b5-9642-8a64a3b1139f)

### Fix

Now, when the user selects ''Task" of type "Other", he/she can clockout once "Description" has values and the error message disappears. 

![Screenshot from 2024-04-07 00-57-24](https://github.com/joshuawootonn/time-track/assets/68671029/29786767-f0c5-476c-ba1c-909d11c426c9)

