### PR TITLE
fix: switching project changes task state

### DIFF
--- a/desktop/src/components/forms/ClockOut/clockOut.jsx
+++ b/desktop/src/components/forms/ClockOut/clockOut.jsx
@@ -130,6 +130,7 @@ export class Clockout extends Component {
                                     items={projects}
                                     fullWidth
                                     label="Project"
+                                    onChange={() => arrayHelpers.form.setFieldValue(`activities.${index}.projectTaskId`, -1)}
                                   />
                                   <Field
                                     name={`activities.${index}.projectTaskId`}


### PR DESCRIPTION
### Bug

When the user is clocking out, the “Task” state keeps the last selected “Task” value. If you switch “Project” to a different one, the “Task” goes blank in the UI. The “Task” value in this state should be default: -1 . But, it is not, the value is still the last SELECTED one until you manually select a task again. 

[bugged_state.webm](https://github.com/joshuawootonn/time-track/assets/68671029/f6fbe1e0-8f31-42b3-a806-b8112db7e390)


### Fix

Now, if you select a project and a task and then switch a project, you are not allowed to clock out, because the task is not selected for the new project and task's value is deafult (-1). 

[fixed_state.webm](https://github.com/joshuawootonn/time-track/assets/68671029/ed3ca4d0-069b-4267-86e9-b1d5883334af)



