### PR TITLE
fix: renamed half shift buttons

### DIFF
--- a/desktop/src/containers/Shift/shiftCRUD.container.jsx
+++ b/desktop/src/containers/Shift/shiftCRUD.container.jsx
@@ -88,7 +88,7 @@ export class ShiftCRUD extends Component {
               isComplete
                 ? [{ type: formConstants.FULL_SHIFT, label: `Full Shift` }]
                 : [
-                    { type: formConstants.HALF_SHIFT, label: `Half Shift` },
+                    { type: formConstants.HALF_SHIFT, label: `Start Shift` },
                     { type: formConstants.FULL_SHIFT, label: `Full Shift` },
                   ]
             }
@@ -243,7 +243,7 @@ export class ShiftCRUD extends Component {
             type={status}
             extent={addingExtent}
             extentOptions={[
-              { type: formConstants.HALF_SHIFT, label: `Half Shift` },
+              { type: formConstants.HALF_SHIFT, label: `Start Shift` },
               { type: formConstants.FULL_SHIFT, label: `Full Shift` },
             ]}
             updateExtent={this.updateExtent}


### PR DESCRIPTION
Renamed 'Half Shift' button labels into 'Start Shift'. These are located in Admin/Shifts/Add Shift or Edit Shift.
