### PR TITLE
fix: dropdown menu quick fix

### DIFF
--- a/desktop/src/components/inputs/TypeableSelect/autoCompleteBase.jsx
+++ b/desktop/src/components/inputs/TypeableSelect/autoCompleteBase.jsx
@@ -335,7 +335,7 @@ class Autocomplete extends React.PureComponent {
             },
           }}
           options={options}
-          menuPosition='fixed'
+          maxMenuHeight='180px'
           components={components}
           onChange={(value) => setFieldValue(field.name, value.id)}
           value={this.getValueFromOptions(options)}


### PR DESCRIPTION
### Summary
Quick fix for dropdown menus (react-select component). The menu does not move all over the place and appropriate items can be selected (tapping on item 1 actually selects item 1).
