### PR TITLE
fix: use clock-out date from backend

### DIFF
--- a/api/lb3app/server/server.js
+++ b/api/lb3app/server/server.js
@@ -1,22 +1,26 @@
-var loopback = require('loopback')
-var boot = require('loopback-boot')
+const loopback = require('loopback')
+const boot = require('loopback-boot')
 require('dotenv').config()
 
-var app = (module.exports = loopback())
+const app = (module.exports = loopback())
 
 app.start = function () {
   // start the web server
   return app.listen(function () {
     app.emit('started')
 
-    var baseUrl = app.get('url').replace(/\/$/, '')
+    const baseUrl = app.get('url').replace(/\/$/, '')
     console.log('Web server listening at: %s', baseUrl)
     if (app.get('loopback-component-explorer')) {
-      var explorerPath = app.get('loopback-component-explorer').mountPath
+      const explorerPath = app.get('loopback-component-explorer').mountPath
       console.log('Browse your REST API at %s%s', baseUrl, explorerPath)
     }
   })
 }
+
+app.get('/now', function (req, res, next) {
+  res.json({ now: new Date().toISOString() });
+});
 
 // Bootstrap the application, configure models, datasources and middleware.
 // Sub-apps like REST API are mounted via boot scripts.

--- a/desktop/src/components/forms/Shift/HalfShift/halfShift.jsx
+++ b/desktop/src/components/forms/Shift/HalfShift/halfShift.jsx
@@ -1,9 +1,11 @@
+import { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 
 import { Grid, Typography, Button, Paper } from '@material-ui/core'
 import cx from 'classnames'
 import { Field, Form } from 'formik'
 import { withStyles } from '@material-ui/core/styles'
+import moment from 'moment'
 
 import TextField from '~/components/inputs/TextField'
 import TypeableSelect from '~/components/inputs/TypeableSelect'
@@ -13,8 +15,14 @@ import styles from './styles'
 import { minutesToString } from '~/helpers/time'
 import { analyzeStatus } from '~/constants/analyze'
 import { getHalfShiftOrNull } from '~/store/Shift/endpoints'
+import { getShiftDuration } from '~/helpers/shiftDuration'
+import axios from '~/helpers/axios'
+
 
 export function HalfShift(props) {
+
+  const [timeRemaining, setTimeRemaining] = useState(null)
+
   const {
     formStatus,
     classes,
@@ -23,10 +31,20 @@ export function HalfShift(props) {
     initialValues,
     errors,
     employees,
-    timeLeft,
     generalError,
     values,
   } = props
+
+  useEffect(() => {
+    axios
+      .get('/now')
+      .then((response) => {
+        const { now } = response.data
+        const clockOut = moment(now)
+        const { lengthRounded } = getShiftDuration(moment(values.clockInDate), clockOut)
+        setTimeRemaining(minutesToString(lengthRounded))
+      })
+  }, [values])
 
   async function validateEmployeeHalfShift(employeeId) {
     if (employeeId === -1 || formStatus !== analyzeStatus.ADDING) {
@@ -66,7 +84,7 @@ export function HalfShift(props) {
 
         <Grid item xs={12} className={cx(classes.row, classes.footerRow)}>
           <Typography variant="h5" margin="none">
-            Current Shift Length: {minutesToString(timeLeft)}
+            Current Shift Length: {timeRemaining !== null ? timeRemaining : ''}
           </Typography>
           <Typography
             color="error"

--- a/desktop/src/containers/Shift/shiftCRUD.container.tsx
+++ b/desktop/src/containers/Shift/shiftCRUD.container.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useState } from 'react'
+import { useState, useEffect } from 'react'
 import { connect } from 'react-redux'
 
 import { Typography } from '@material-ui/core'
@@ -25,6 +25,7 @@ import {
   halfShift as halfShiftValidation,
 } from '~/constants/formValidation'
 import { getShiftDuration } from '~/helpers/shiftDuration'
+import axios from '~/helpers/axios'
 
 export function ShiftCRUD(props: any) {
 
@@ -37,6 +38,18 @@ export function ShiftCRUD(props: any) {
 
   const { selected, status, projects, projectTasks, employees } = props
   const { editingExtent, addingExtent } = state
+
+  const [currentMoment, setCurrentMoment] = useState<any | null>(null)
+
+  useEffect(() => {
+    axios
+      .get('/now')
+      .then((response: any) => {
+        const { now } = response.data
+        const clockOut = moment(now).utc().local().format(`YYYY-MM-DDTHH:mm:ss`)
+        setCurrentMoment(clockOut)
+      })
+  }, [selected, editingExtent, addingExtent])
 
   const removeShift = () => {
     const { selected, removeShift } = props
@@ -130,12 +143,6 @@ export function ShiftCRUD(props: any) {
               )
             }}
             render={(formikProps) => {
-
-              const { values } = formikProps
-
-              const clockOutMoment = moment(new Date(), 'YYYY-MM-DDTHH:mm:ss')
-              const { lengthRounded } = getShiftDuration(moment(values.clockInDate), clockOutMoment)
-
               return (
                 <HalfShiftForm
                   formStatus={status}
@@ -145,7 +152,6 @@ export function ShiftCRUD(props: any) {
                   employees={employees}
                   projects={projects}
                   projectTasks={projectTasks}
-                  timeLeft={lengthRounded}
                   generalError={``}
                   removeShift={removeShift}
                   {...formikProps}
@@ -169,7 +175,7 @@ export function ShiftCRUD(props: any) {
                   .utc(selected.clockOutDate, `YYYY-MM-DDThh:mm:ss:SSS`)
                   .local()
                   .format(`YYYY-MM-DDTHH:mm:ss`)
-                : moment.utc().local().format(`YYYY-MM-DDTHH:mm:ss`),
+                : currentMoment,
               lunch: selected.lunch,
               activities: selected.activities
                 ? selected.activities.map((activity: any) => {
@@ -314,7 +320,7 @@ export function ShiftCRUD(props: any) {
                 .startOf(`day`)
                 .add(`minutes`, 450)
                 .format(`YYYY-MM-DDTHH:mm:ss`),
-              clockOutDate: moment().format(`YYYY-MM-DDTHH:mm:ss`),
+              clockOutDate: currentMoment,
               employeeId: -1,
               activities: [
                 {


### PR DESCRIPTION
Initial issue: 

Time comes from the device, meaning if a device 1 shows 2:00p and device 2 shows 2:20p, the user can clock in on device 1 and then instantly clock out on device 2: the shift length will be 20 mins, which is incorrect.

Solution:

Time comes from the server, meaning that device time is irrelevant. In the same scenario as mentioned above, the system will not allow the user to clock out, as based on server time, only a few seconds lasted. 
