### PR TITLE
fix: full shift editing fix

### DIFF
--- a/desktop/src/containers/Shift/shiftCRUD.container.tsx
+++ b/desktop/src/containers/Shift/shiftCRUD.container.tsx
@@ -39,7 +39,7 @@ export function ShiftCRUD(props: any) {
   const { selected, status, projects, projectTasks, employees } = props
   const { editingExtent, addingExtent } = state
 
-  const [currentMoment, setCurrentMoment] = useState<any | null>(null)
+  const [currentMoment, setCurrentMoment] = useState<string | null>(null)
 
   useEffect(() => {
     axios
@@ -53,7 +53,6 @@ export function ShiftCRUD(props: any) {
 
   const removeShift = () => {
     const { selected, removeShift } = props
-    console.log(selected, removeShift)
     removeShift(selected.id)
   }
 
@@ -76,6 +75,13 @@ export function ShiftCRUD(props: any) {
     status === analyzeStatus.EDITING &&
     selected &&
     selected.clockOutDate !== null
+
+  useEffect(() => {
+    if (isComplete && (editingExtent !== formConstants.FULL_SHIFT)) {
+      updateExtent(analyzeStatus.EDITING, formConstants.FULL_SHIFT)
+    }
+  }, [isComplete, editingExtent])
+
   if (status === analyzeStatus.INIT) {
     return (
       <Hero fullWidth fullHeight>
@@ -101,6 +107,7 @@ export function ShiftCRUD(props: any) {
           label="Edit Shift"
           remove={removeShift}
           type={status}
+          // @ts-expect-error: types
           extent={isComplete ? formConstants.FULL_SHIFT : editingExtent}
           extentOptions={
             isComplete
@@ -251,6 +258,7 @@ export function ShiftCRUD(props: any) {
         <FormHeader
           label="Add Shift"
           type={status}
+          // @ts-expect-error: types
           extent={addingExtent}
           extentOptions={[
             { type: formConstants.HALF_SHIFT, label: `Start Shift` },


### PR DESCRIPTION
Before, it was possible to edit a full shift in a start shift mode. When doing so, timetrack does not catch the change properly which can lead to infinite clockins/clockouts for a specific user. 

Now, the user is not allowed to edit a full shift in a start shift mode, which eliminates the scenario from above.  

Notion bug info: https://www.notion.so/wootonn/422b16a38cea463793e87a7345b3bc2a?v=464acd20133b4cd7b4e8b21d7b233d64&p=c3d6ba0cda6a437babfb2f0c5bf77275&pm=s

Video demo of the bug:


https://github.com/user-attachments/assets/877eb20a-1ff5-492c-9fbe-ea893dbcddb2

