### PR TITLE
fix: ee number state fix

### DIFF
--- a/desktop/src/containers/Employee/employeeCRUD.container.jsx
+++ b/desktop/src/containers/Employee/employeeCRUD.container.jsx
@@ -55,6 +55,7 @@ export class EmployeeCRUD extends Component {
               ...values,
               isEmployed: values.isEmployed ? 1 : 0,
               isWorking: values.isWorking ? 1 : 0,
+              eeNumber: values.eeNumber ?? '',
             }).then(
               () => {
                 formikFunctions.resetForm()
@@ -90,6 +91,7 @@ export class EmployeeCRUD extends Component {
             ...selected,
             isEmployed: selected.isEmployed ? true : false,
             isWorking: selected.isWorking ? true : false,
+            eeNumber: selected.eeNumber ?? '',
           }}
           validationSchema={employeeValidation}
           onSubmit={(values, formikFunctions) => {


### PR DESCRIPTION
Before, when switching from an employee with ee number to the one without, the ee number state would transfer to the blank one. Now, it does not, ee numbers can be blank.
